### PR TITLE
#82 calculate peak latency as average of top 5% slowest requests

### DIFF
--- a/src/phpRack/Package/Qos.php
+++ b/src/phpRack/Package/Qos.php
@@ -62,6 +62,7 @@ class phpRack_Package_Qos extends phpRack_Package
         require_once PHPRACK_PATH . '/Adapters/Url.php';
         $totalRequestsTime = 0;
         $requestsCompleted = 0;
+        $requestTimesMs = array();
         reset($options['scenario']);
         while ($requestsCompleted < $options['testsTotal']) {
             $url = current($options['scenario']);
@@ -79,16 +80,24 @@ class phpRack_Package_Qos extends phpRack_Package
                 "HTTP to {$url}: {$requestTimeInMs}ms, "
                 . strlen($content) . ' bytes'
             );
-            // check single query time meets limit
-            if ($requestTimeInMs > $options['peakMs']) {
-                $this->_failure(
-                    "Peak latency is {$requestTimeInMs}ms, but value below {$options['peakMs']}ms was expected"
-                );
-                return $this;
-            }
+            $requestTimesMs[] = $requestTimeInMs;
             $totalRequestsTime += $requestTime;
             $requestsCompleted++;
             next($options['scenario']);
+        }
+        // peak latency is the average of the 5% slowest requests (#82)
+        rsort($requestTimesMs);
+        $topCount = max(1, (int) ceil(count($requestTimesMs) * 0.05));
+        $topSum = 0;
+        for ($i = 0; $i < $topCount; $i++) {
+            $topSum += $requestTimesMs[$i];
+        }
+        $peakMs = intval($topSum / $topCount);
+        if ($peakMs > $options['peakMs']) {
+            $this->_failure(
+                "Peak latency is {$peakMs}ms, but value below {$options['peakMs']}ms was expected"
+            );
+            return $this;
         }
         // check average queries time meets limit
         $averageMs = intval($totalRequestsTime / $options['testsTotal'] * 1000);


### PR DESCRIPTION
The `phpRack_Package_Qos::latency()` method failed the run on the first individual request that crossed `peakMs`, treating a single sample as the peak. Issue #82 specifies the peak as the average of the top 5 percent slowest requests instead.

`src/phpRack/Package/Qos.php` now collects every per-request millisecond reading into `$requestTimesMs`, sorts them descending after the scenario finishes, averages the top 5 percent (rounded up to at least one entry, so single-request scenarios still get a peak), and compares that average against `options.peakMs`. Average-latency handling and the rest of the method are unchanged.

I ran `php -l src/phpRack/Package/Qos.php`, then `composer install --no-interaction --prefer-dist` and `vendor/bin/phpunit --configuration phpunit.xml` on PHP 8.4 in this checkout: 157 tests, 178 assertions, 0 failures (matching master, the unrelated deprecations and skips are pre-existing). `vendor/bin/phpcs --standard=Zend -n src/phpRack/Package/Qos.php` is clean.

Closes #82